### PR TITLE
Remove warnings

### DIFF
--- a/lib/minitest/slow_test.rb
+++ b/lib/minitest/slow_test.rb
@@ -3,10 +3,13 @@ require 'minitest/slow_test/version'
 module Minitest
   module SlowTest
     class << self
-      attr_accessor :long_test_time
+      attr_writer :long_test_time
 
       def long_test_time
-        (@long_test_time || 1.0).to_f
+        unless defined? @long_test_time
+          @long_test_time = 1.0
+        end
+        @long_test_time.to_f
       end
     end
   end


### PR DESCRIPTION
1. lib/minitest/slow_test.rb:8: warning: method redefined; discarding old long_test_time
2. lib/minitest/slow_test.rb:9: warning: instance variable @long_test_time not initialized